### PR TITLE
user model completed

### DIFF
--- a/IronWars/src/main/java/com/YronJack/IronWars/model/PersonalData.java
+++ b/IronWars/src/main/java/com/YronJack/IronWars/model/PersonalData.java
@@ -1,4 +1,34 @@
 package com.YronJack.IronWars.model;
 
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Embeddable
 public class PersonalData {
+
+    @NotBlank(message = "The field name is necessary")
+    @Size(max = 100, message = "Name hasn't contained more than 100 characters")
+    private String name;
+
+    @NotBlank(message = "The field Last Name is necessary")
+    @Size(max = 100, message = "Last Name hasn't contained more than 100 characters")
+    private String lastName;
+
+    @NotBlank(message = "The field address is necessary")
+    private String address;
+
+    @NotBlank(message = "El email es obligatorio")
+    @Email(message = "El email no tiene un formato válido")
+    @Size(max = 150, message = "El email no puede tener más de 150 caracteres")
+    @Column(nullable = false, length = 150, unique = true)
+    private String email;
+
+    private String phone;
+
 }

--- a/IronWars/src/main/java/com/YronJack/IronWars/model/User.java
+++ b/IronWars/src/main/java/com/YronJack/IronWars/model/User.java
@@ -1,4 +1,30 @@
 package com.YronJack.IronWars.model;
 
-public class User {
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public abstract class  User {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @NotBlank(message = "The field nickName is necessary")
+    @Size(max = 100, message = "Nickname hasn't contained more than 100 characters")
+    private String nickName;
+
+    @NotBlank(message = "Password is required")
+    @Size(min = 8, max = 100, message = "The password hasn't contained more than 100 characters")
+    @Column(nullable = false, length = 100)
+    private Long password;
+
+    @Embedded
+    private PersonalData personalData;
+
 }


### PR DESCRIPTION
This pull request introduces significant improvements to the `User` and `PersonalData` models by adding validation, persistence annotations, and leveraging Lombok to reduce boilerplate code. These changes enhance data integrity, simplify code maintenance, and prepare the models for use with JPA/Hibernate.

**Model enhancements and validation:**

* Added JPA annotations (`@Embeddable`, `@Embedded`, `@Id`, `@GeneratedValue`, `@Column`) to both `PersonalData` and `User` classes for proper persistence mapping. (`[[1]](diffhunk://#diff-12cb8f51c76e392d32777341707352315f1dbb3e9339f977212a38d6de67cdc2R3-R33)`, `[[2]](diffhunk://#diff-4e1c5d08550dbf20686e8b9fb7b30bf612c30fe316b2587c036fa86dd8039666L3-R29)`)
* Introduced validation constraints (`@NotBlank`, `@Size`, `@Email`) to ensure required fields and valid data formats in both models. (`[[1]](diffhunk://#diff-12cb8f51c76e392d32777341707352315f1dbb3e9339f977212a38d6de67cdc2R3-R33)`, `[[2]](diffhunk://#diff-4e1c5d08550dbf20686e8b9fb7b30bf612c30fe316b2587c036fa86dd8039666L3-R29)`)
* Incorporated Lombok annotations (`@Data`, `@NoArgsConstructor`, `@AllArgsConstructor`) to automatically generate getters, setters, and constructors, reducing boilerplate code. (`[[1]](diffhunk://#diff-12cb8f51c76e392d32777341707352315f1dbb3e9339f977212a38d6de67cdc2R3-R33)`, `[[2]](diffhunk://#diff-4e1c5d08550dbf20686e8b9fb7b30bf612c30fe316b2587c036fa86dd8039666L3-R29)`)

**Structural changes:**

* Made `User` an abstract class and added fields for `id`, `nickName`, `password`, and an embedded `PersonalData` object. (`[IronWars/src/main/java/com/YronJack/IronWars/model/User.javaL3-R29](diffhunk://#diff-4e1c5d08550dbf20686e8b9fb7b30bf612c30fe316b2587c036fa86dd8039666L3-R29)`)
* Defined new fields in `PersonalData` (`name`, `lastName`, `address`, `email`, `phone`) with appropriate validation and column settings. (`[IronWars/src/main/java/com/YronJack/IronWars/model/PersonalData.javaR3-R33](diffhunk://#diff-12cb8f51c76e392d32777341707352315f1dbb3e9339f977212a38d6de67cdc2R3-R33)`)